### PR TITLE
enter and exit rng scope

### DIFF
--- a/src/code.cpp
+++ b/src/code.cpp
@@ -90,12 +90,23 @@ cpp11::writable::integers_matrix run_turmite(int width, int height, int iter, in
   return grid;
 }
 
+struct RNGScope {
+  RNGScope() {
+    GetRNGstate();
+  }
+
+  ~RNGScope(){
+    PutRNGstate();
+  }
+};
+
 }
 
 
 // turmite function to be called from R
 [[cpp11::register]]
 cpp11::writable::integers_matrix turmite(int width, int height, int iter, int step_size) {
+  trmt::RNGScope rng_scope;
   return trmt::run_turmite(width, height, iter, step_size);
 }
 


### PR DESCRIPTION
Because `trmt::run_turmite()` uses R's random number generation, this needs to enter and exit rng state. This was done automatically by Rcpp and is not done by `cpp11` code decoration. 

I can investigate more if this does not fix the problem discussed on twitter. I believe however that this change needs to happen anyway. 

This is done with a simple `RNGScope` class: 

```cpp
struct RNGScope {
  RNGScope() {
    GetRNGstate();
  }

  ~RNGScope(){
    PutRNGstate();
  }
};
```

I don't think `cpp11` has something for this already. cc @jimhester